### PR TITLE
Uses regexp for identifying lineinfile env var updates

### DIFF
--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -54,6 +54,7 @@
   lineinfile:
     dest: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}/bin/environment"
     line: "{{ item.key }}={{ item.value }}"
+    regexp: "^{{ item.key }}="
     create: yes
   no_log: true
   with_dict: "{{ django_stack_gunicorn_default_envs|combine(django_stack_gunicorn_opt_envs) }}"


### PR DESCRIPTION
Without the `regexp` parameter, the `lineinfile` module will blindly
append lines unless an identical line already exists. In the context of
INI-style `key=value` pairs, we want to update lines where only the
value has changed, rather than append again.