### PR TITLE
Django manage tasks restructure.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,7 @@ django_stack_db_tasks:
   - migrate
   - collectstatic
 django_stack_manage_post: []
+django_stack_manage_pre: []
 
 django_stack_gunicorn_default_envs:
   DJANGO_DB_USER: "{{ django_db_user }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -153,3 +153,5 @@
       - update_index
     django_stack_npm_commands:
       - run build
+    django_stack_gunicorn_opt_envs:
+      DJANGO_ALLOWED_HOSTS: "'*'"

--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -61,18 +61,29 @@
   notify: Restart Gunicorn
 
 - block:
-  - name: Database initialization and misc tasks
+  # Designed to only be one once per install
+  - name: Django optional pre db commands
+    django_manage:
+      command: "{{ item }}"
+      app_path: "{{ django_stack_app_dir }}"
+      settings: "{{ django_stack_gcorn_app_settings }}"
+      virtualenv: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}"
+    with_items: ["{{ django_stack_manage_pre }}"]
+    ignore_errors: yes
+    when: not venv_folder.stat.exists
+
+  - name: Database migrate and other idempotent tasks
     django_manage:
       command: "{{ item }}"
       app_path: "{{ django_stack_app_dir }}"
       settings: "{{ django_stack_gcorn_app_settings }}"
       virtualenv: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}"
     with_items: "{{ django_stack_db_tasks }}"
-    register: database
-    when: not venv_folder.stat.exists or item == 'collectstatic'
+    register: database_register
     notify: Restart Gunicorn
 
-  - name: Django optional post commands
+  # Designed to only be one once per install
+  - name: Django optional post db commands
     django_manage:
       command: "{{ item }}"
       app_path: "{{ django_stack_app_dir }}"
@@ -80,7 +91,7 @@
       virtualenv: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}"
     with_items: ["{{ django_stack_manage_post }}"]
     ignore_errors: yes
-    when: database.changed
+    when: not venv_folder.stat.exists
 
   become_user: "{{ django_stack_gcorn_user }}"
   environment: "{{ django_stack_gunicorn_default_envs|combine(django_stack_gunicorn_opt_envs) }}"


### PR DESCRIPTION
Set-up the django task so it now looks like this:

1. manage.py optional pre-tasks (only get run once per install)
2. manage.py idempotent tasks (should get run everytime)
3. manage.py optional post-tasks (only get run once per install)