### PR TITLE
Allow over-ride of pip and npm package detection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,3 +79,8 @@ django_stack_gunicorn_default_envs:
   DJANGO_ES_HOST: "{{ django_stack_es_host_url }}"
   DJANGO_ES_CA_PATH: "{{ django_stack_es_ca_path }}"
 django_stack_gunicorn_opt_envs: {}
+
+# if set to true, force reinstall of npm and pip packages
+# useful for situations were we are disabling the pulling
+# of code via git
+django_stack_force_refresh: false

--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -25,7 +25,7 @@
         virtualenv_python: "{{ django_stack_venv_python }}"
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
       notify: Restart Gunicorn
-      when: "git_pull.changed or not venv_folder.stat.exists"
+      when: "git_pull.changed or not venv_folder.stat.exists or django_stack_force_refresh"
 
   rescue:
     - name: Setup virtualenv from requirements file
@@ -35,7 +35,7 @@
         executable: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}/bin/pip"
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
       notify: Restart Gunicorn
-      when: "git_pull.changed or not venv_folder.stat.exists"
+      when: "git_pull.changed or not venv_folder.stat.exists or django_stack_force_refresh"
   become_user: "{{ django_stack_gcorn_user }}"
 
 - name: Ensure environment parameters are sufficiently exported

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -22,7 +22,7 @@
     raw: cd "{{ django_stack_npm_dir }}" && npm install
     register: npm_install
     #changed_when: "'install' in npm_install.std_out"
-    when: git_pull is undefined or git_pull.changed
+    when: "git_pull is undefined or git_pull.changed or django_stack_force_refresh"
 
   - name: Optional npm commands
     shell: "npm {{ item }}"
@@ -30,7 +30,7 @@
       chdir: "{{ django_stack_npm_dir }}"
       executable: /bin/bash
     with_items: "{{ django_stack_npm_commands }}"
-    when: npm_install is defined and npm_install.changed
+    when: "npm_install is defined and npm_install.changed"
 
   - name: Optional shell commands
     shell: "{{ item }}"


### PR DESCRIPTION
Typically we were relying on Git pull changes on the django code
to determine when we instal NPM + Virtualenv packages. Ran into a recent
situation where we disabled the git pull task so the node packages
werent getting properly installed. This provides a new variable
(defaults to false) that will force attempt to install npm and virtualenv
packages.