### PR TITLE
Allow rsync instead of git pull

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,3 +92,6 @@ django_stack_gunicorn_opt_envs: {}
 # useful for situations were we are disabling the pulling
 # of code via git
 django_stack_force_refresh: false
+
+django_stack_rsync_opts:
+  - "--exclude=.git"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ django_stack_es_host_url: http://localhost:9200
 django_stack_es_ca_path: /etc/ssl/certs/testca_freedom_press.pem
 
 #npm settings
+django_stack_npm_install_cmd: npm install
 django_stack_npm_dir: "{{ django_stack_app_dir }}"
 django_stack_npm_commands: []
 django_stack_npm_global_pkgs: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,11 @@ django_stack_git_pkgs:
 django_stack_git_repo: []
 django_stack_git_deploy: []
 
+# rsync code parameters
+django_stack_rsync_pkgs:
+  - rsync
+django_stack_deploy_src: ""
+
 # django post manage.py tasks
 django_stack_db_tasks:
   - migrate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,6 @@
   tags: ['always']
 
 - include: pull_sitecode.yml
-  when: django_stack_git_repo != []
   tags: ['git']
 
 - include: npm.yml

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -19,7 +19,7 @@
   - name: NPM dependency install
     # ran into a lot of issues using the ansible npm, shell, command modules
     # had to fall back to raw to press forward
-    raw: cd "{{ django_stack_npm_dir }}" && npm install
+    raw: "cd {{ django_stack_npm_dir }} && {{ django_stack_npm_install_cmd }}"
     register: npm_install
     #changed_when: "'install' in npm_install.std_out"
     when: "git_pull is undefined or git_pull.changed or django_stack_force_refresh"

--- a/tasks/pull_sitecode.yml
+++ b/tasks/pull_sitecode.yml
@@ -50,6 +50,5 @@
     dest: "{{ django_stack_deploy_dir }}"
     src: "{{ django_stack_deploy_src }}"
     delete: yes
-    rsync_opts:
-      - "--exclude=.git"
+    rsync_opts: "{{ django_stack_rsync_opts }}"
   when: "not django_stack_git_repo and django_stack_deploy_src"

--- a/tasks/pull_sitecode.yml
+++ b/tasks/pull_sitecode.yml
@@ -36,3 +36,20 @@
     recursive: "{{ item.recursive|default('yes') }}"
   register: git_pull
   with_items: "{{ django_stack_git_repo }}"
+
+# Conditionally install rsync and copy a specified code directory
+# over to our target server. This logic is INSTEAD of pulling code via git
+- name: Conditionally install rsync
+  package:
+    name: "{{ item }}"
+  with_items: "{{ django_stack_rsync_pkgs }}"
+  when: "not django_stack_git_repo and django_stack_deploy_src"
+
+- name: Conditionally lets rsync the current files up
+  synchronize:
+    dest: "{{ django_stack_deploy_dir }}"
+    src: "{{ django_stack_deploy_src }}"
+    delete: yes
+    rsync_opts:
+      - "--exclude=.git"
+  when: "not django_stack_git_repo and django_stack_deploy_src"


### PR DESCRIPTION
This PR does two things,

* Allows utilization of rsync to get source directory to the remote server. This is opposed to getting the code via git. This particularly good for testing and works under my friend `docker` with `ansible 2.3+`. 

* Allows over-riding of the npm install command. This needed to be tweaked on certain sites ... because node is wacky.
