### PR TITLE
Fixes edge-case for rsync detection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ django_stack_db_tasks:
   - migrate
   - collectstatic
 django_stack_manage_post: []
+django_stack_manage_post_ignore: yes
 django_stack_manage_pre: []
 
 django_stack_gunicorn_default_envs:

--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -89,7 +89,7 @@
       settings: "{{ django_stack_gcorn_app_settings }}"
       virtualenv: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}"
     with_items: ["{{ django_stack_manage_post }}"]
-    ignore_errors: yes
+    ignore_errors: "{{ django_stack_manage_post_ignore }}"
     when: not venv_folder.stat.exists
 
   become_user: "{{ django_stack_gcorn_user }}"

--- a/tasks/pull_sitecode.yml
+++ b/tasks/pull_sitecode.yml
@@ -56,7 +56,7 @@
     rsync_opts: "{{ django_stack_rsync_opts }}"
   when:
     - not django_stack_git_repo
-    - django_stack_deploy_src
+    - "not django_stack_deploy_src == ''"
 
 - name: Optional copy over local django settings
   copy:


### PR DESCRIPTION
The current rsync detection logic afflicted other test roles that depended on rsyncin' the files
around as opposed to using git_pull. Seemed to be kind of inconsistent with failures - I'm
surprised this wasnt caught before to be honest.