### PR TITLE
Option to reduce role output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ tests:
 
 .PHONY: teardown
 teardown:
-	docker kill prod && docker rm -f prod
+	docker rm -f django_stack_prod

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These are the following system requirements:
 Role Variables
 --------------
 
-```
+```yaml
 # defaults file for fpf-django-stack
 django_stack_app_name: fpf
 django_stack_deploy_dir: /var/www/django
@@ -46,9 +46,15 @@ django_stack_gcorn_workers: 8
 django_stack_gcorn_threads: 4
 django_stack_gcorn_loglevel: info
 
+# If you want to try to keep output to a minimum, toggle this on.
+# For example, in CI verbose built output can obscure relevant test info.
+django_stack_global_no_log: no
+
 # virtualenv and pip
 django_stack_venv_python: python3
 django_stack_venv_sitepackage: no
+django_stack_venv_no_log: "{{ django_stack_global_no_log }}"
+django_stack_venv_base_pkgs: []
 django_stack_optional_pip: []
 # - name: django
 #   python: python2
@@ -68,6 +74,7 @@ django_stack_npm_install_cmd: npm install
 django_stack_npm_dir: "{{ django_stack_app_dir }}"
 django_stack_npm_commands: []
 django_stack_npm_global_pkgs: []
+django_stack_npm_no_log: "{{ django_stack_global_no_log }}"
 django_stack_shell_commands: []
 
 django_stack_pkgs:
@@ -93,6 +100,7 @@ django_stack_git_deploy: []
 # rsync code parameters
 django_stack_rsync_pkgs:
   - rsync
+django_stack_rsync_no_log: "{{ django_stack_global_no_log }}"
 django_stack_deploy_src: ""
 
 # django post manage.py tasks
@@ -100,10 +108,10 @@ django_stack_db_tasks:
   - migrate
   - collectstatic
 django_stack_manage_post: []
+django_stack_manage_post_ignore: yes
 django_stack_manage_pre: []
+django_stack_manage_no_log: "{{ django_stack_global_no_log }}"
 
-# These will only work if you have a django settings file that
-# takes advantage of these environment variables
 django_stack_gunicorn_default_envs:
   DJANGO_DB_USER: "{{ django_db_user }}"
   DJANGO_DB_PASSWORD: "{{ django_db_password }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,8 @@ django_stack_gcorn_workers: 8
 django_stack_gcorn_threads: 4
 django_stack_gcorn_loglevel: info
 
-# If you want to try to keep output to a minimum, toggle this on
+# If you want to try to keep output to a minimum, toggle this on.
+# For example, in CI verbose built output can obscure relevant test info.
 django_stack_global_no_log: no
 
 # virtualenv and pip

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,13 @@ django_stack_gcorn_workers: 8
 django_stack_gcorn_threads: 4
 django_stack_gcorn_loglevel: info
 
+# If you want to try to keep output to a minimum, toggle this on
+django_stack_global_no_log: no
+
 # virtualenv and pip
 django_stack_venv_python: python3
 django_stack_venv_sitepackage: no
+django_stack_venv_no_log: "{{ django_stack_global_no_log }}"
 django_stack_venv_base_pkgs: []
 django_stack_optional_pip: []
 # - name: django
@@ -44,6 +48,7 @@ django_stack_npm_install_cmd: npm install
 django_stack_npm_dir: "{{ django_stack_app_dir }}"
 django_stack_npm_commands: []
 django_stack_npm_global_pkgs: []
+django_stack_npm_no_log: "{{ django_stack_global_no_log }}"
 django_stack_shell_commands: []
 
 django_stack_pkgs:
@@ -69,6 +74,7 @@ django_stack_git_deploy: []
 # rsync code parameters
 django_stack_rsync_pkgs:
   - rsync
+django_stack_rsync_no_log: "{{ django_stack_global_no_log }}"
 django_stack_deploy_src: ""
 
 # django post manage.py tasks
@@ -78,6 +84,7 @@ django_stack_db_tasks:
 django_stack_manage_post: []
 django_stack_manage_post_ignore: yes
 django_stack_manage_pre: []
+django_stack_manage_no_log: "{{ django_stack_global_no_log }}"
 
 django_stack_gunicorn_default_envs:
   DJANGO_DB_USER: "{{ django_db_user }}"

--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -51,6 +51,9 @@
       - postcss-cli
     django_stack_venv_python: python2
     django_stack_override_config: local.py
+    # Lets restrict output
+    django_stack_global_no_log: yes
+
   handlers:
     - name: restart paxctld
       service:

--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -26,6 +26,7 @@
     virtualenv_python: "{{ django_stack_venv_python }}"
     virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
     extra_args: "-U"
+  no_log: "{{ django_stack_venv_no_log }}"
   with_items: "{{ ['pip'] + django_stack_venv_base_pkgs }}"
   become_user: "{{ django_stack_gcorn_user }}"
 
@@ -36,6 +37,7 @@
     virtualenv_python: "{{ django_stack_venv_python }}"
     virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
     extra_args: "-U --upgrade-strategy only-if-needed"
+  no_log: "{{ django_stack_venv_no_log }}"
   notify: Restart Gunicorn
   when: "git_pull_register.changed or not venv_folder.stat.exists or django_stack_force_refresh"
   become_user: "{{ django_stack_gcorn_user }}"
@@ -78,6 +80,7 @@
       settings: "{{ django_stack_gcorn_app_settings }}"
       virtualenv: "{{ django_stack_gcorn_home }}/{{ django_stack_app_name }}"
     with_items: "{{ django_stack_db_tasks }}"
+    no_log: "{{ django_stack_manage_no_log }}"
     register: database_register
     notify: Restart Gunicorn
 

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -42,7 +42,7 @@
 
   become_user: "{{ django_stack_gcorn_user }}"
   become: yes
+  no_log: "{{ django_stack_npm_no_log }}"
   environment:
     NODE_ENV: production
     NODE_PATH: /usr/lib/nodejs:/usr/lib/node_modules:/usr/share/javascript:/usr/local/lib/npm/lib/node_modules
-

--- a/tasks/pull_sitecode.yml
+++ b/tasks/pull_sitecode.yml
@@ -54,6 +54,7 @@
     src: "{{ django_stack_deploy_src }}"
     delete: yes
     rsync_opts: "{{ django_stack_rsync_opts }}"
+  no_log: "{{ django_stack_rsync_no_log }}"
   when:
     - not django_stack_git_repo
     - "not django_stack_deploy_src == ''"


### PR DESCRIPTION
Some of the tasks are rather noisy, like npm and pip, regardless of if there are any real changes. This PR allows disabling of log output for many of those noisy tasks (either globally or a per task via a set of variable additions).

This PR is based-off #21 so please marge that first.