### PR TITLE
Updates apt cache in venv builder container

### DIFF
--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -21,7 +21,9 @@
     - name: Install system dependencies
       apt:
         name: "{{ item }}"
-      with_items: ["{{ django_stack_pkgs }}"]
+        update_cache: yes
+        cache_valid_time: 3600
+      with_items: "{{ django_stack_pkgs }}"
       tags: ['pkgs']
 
     # Necessary because there is no way to pass --relocatable to virtualenv from


### PR DESCRIPTION
The `apt` module logic that applies to the local container for
constructing the virtualenv did not have an update_cache parameter.
It's not possible to target the build container at the play-level, as a
form of override, since the build container is temporary, created and
destroyed within the lifecycle of a single role run.

Unfortunately it's not a simple matter to add config tests to validate
the new behavior: any packages listed in `django_stack_pkgs` will *not*
be present in the configured container after role execution—those
packages were installed only within the temporary build container.

Closes #30.