### PR TITLE
Permits overriding of NodeJS local build container

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,9 @@ django_stack_shell_commands: []
 # This is the tag for the node image used locally to prepare the code
 django_stack_node_ver: 6.11.0-alpine
 
+# Default to a slim node Dockerfile shipped with role, but permit overrides.
+django_stack_node_dockerfile: "{{ role_path }}/docker/NodeDockerfile"
+
 django_stack_pkgs:
   - gcc
   - g++

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -33,13 +33,11 @@
           - "{{ tmp_dir }}:/status"
         state: started
         working_dir: "{{ active_deploy_dir }}"
-        command: /bin/ash -c "{{django_stack_npm_install_cmd}}; touch /status/npm.done"
+        command: /bin/ash -c "{{ django_stack_npm_install_cmd }}"
         user: "{{ 'node' if (lookup('pipe','id -u') == '1000') else omit }}"
+        # Block until command is finished; report failure on error
+        detach: no
         recreate: "yes"
-
-    - name: Wait for node logic to finish up
-      wait_for:
-        path: "{{ tmp_dir }}/npm.done"
 
   become: "no"
   delegate_to: localhost

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -22,6 +22,7 @@
         dockerfile: "{{ django_stack_node_dockerfile }}"
         path: ../../
         tag: "{{ django_stack_node_ver }}"
+        force: yes
       when: ansible_kernel.endswith('grsec')
 
     - name: Node local docker builder
@@ -38,6 +39,7 @@
         # Block until command is finished; report failure on error
         detach: no
         recreate: "yes"
+        keep_volumes: no
 
   become: "no"
   delegate_to: localhost

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -18,12 +18,11 @@
 
     - name: Prepare node image with pax flags
       docker_image:
-        name: "node_grsec:{{ django_stack_node_ver }}"
+        name: "{{ nocde_grsec_image|default('node') }}:{{ django_stack_node_ver }}"
         dockerfile: "{{ django_stack_node_dockerfile }}"
         path: ../../
         tag: "{{ django_stack_node_ver }}"
         force: yes
-      when: ansible_kernel.endswith('grsec')
 
     - name: Node local docker builder
       docker_container:

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -19,7 +19,7 @@
     - name: Prepare node image with pax flags
       docker_image:
         name: "node_grsec:{{ django_stack_node_ver }}"
-        dockerfile: "{{ role_path }}/docker/NodeDockerfile"
+        dockerfile: "{{ django_stack_node_dockerfile }}"
         path: ../../
         tag: "{{ django_stack_node_ver }}"
       when: ansible_kernel.endswith('grsec')


### PR DESCRIPTION
Needed these changes over in https://github.com/freedomofpress/securethenews/pull/123, since the Gulp-based static asset management used in STN requires more packages to be installed within the Node build container. Although there's a `django_stack_npm_global_pkgs` var for providing global NPM packages, e.g. `gulp-cli`, those packages do _not_ get installed in the NodeJS container, and so aren't useful for the STN config. 

The default config for the NodeJS container image is the same—it's just overrideable now. Minor changes to the NodeJS build logic include setting `detach=no`, so we don't have to wait for a `touch`ed file, and also so Ansible reports errors if the commands failed. Also, I set `keep_volumes=no`, but I believe that might be superfluous for this particular use case. Trying to ensure that builds are always clean.