### PR TITLE
Node context

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,7 @@ django_stack_node_ver: 6.11.0-alpine
 
 # Default to a slim node Dockerfile shipped with role, but permit overrides.
 django_stack_node_dockerfile: "{{ role_path }}/docker/NodeDockerfile"
+django_stack_node_dockercontext: "{{ role_path }}/docker"
 
 django_stack_pkgs:
   - gcc

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -20,7 +20,7 @@
       docker_image:
         name: "{{ node_grsec_image|default('node') }}:{{ django_stack_node_ver }}"
         dockerfile: "{{ django_stack_node_dockerfile }}"
-        path: ../../
+        path: "{{ django_stack_node_dockercontext }}"
         tag: "{{ django_stack_node_ver }}"
         force: yes
 

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -18,7 +18,7 @@
 
     - name: Prepare node image with pax flags
       docker_image:
-        name: "{{ nocde_grsec_image|default('node') }}:{{ django_stack_node_ver }}"
+        name: "{{ node_grsec_image|default('node') }}:{{ django_stack_node_ver }}"
         dockerfile: "{{ django_stack_node_dockerfile }}"
         path: ../../
         tag: "{{ django_stack_node_ver }}"


### PR DESCRIPTION
The previous `../../` was dangerous when run from a playbook because it adapted
context relative to the playbook location. The way context works in the docker build process is that it shoves all of that into a package up filesystem that docker can read from and then discards that at the end of the build.

This ended up crashing my system since two directories relative to my playbook call sits all of my git repos which were larger than my system tmp space :) 

This PR fixes #33