### PR TITLE
Allow override of docker image for virtualenv

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,8 @@ django_stack_venv_python: python3
 django_stack_venv_sitepackage: no
 django_stack_venv_no_log: "{{ django_stack_global_no_log }}"
 django_stack_venv_base_pkgs: []
+django_stack_venv_docker_volumes: []
+django_stack_venv_docker_image: "quay.io/freedomofpress/ci-webserver:latest"
 django_stack_optional_pip: []
 # - name: django
 #   python: python2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ django_stack_venv_python: python3
 django_stack_venv_sitepackage: no
 django_stack_venv_no_log: "{{ django_stack_global_no_log }}"
 django_stack_venv_base_pkgs: []
+django_stack_venv_cmds: []
 django_stack_venv_docker_volumes: []
 django_stack_venv_docker_image: "quay.io/freedomofpress/ci-webserver:latest"
 django_stack_optional_pip: []

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -2,13 +2,10 @@
 - name: Fire-up docker container used for building virtualenv
   docker_container:
     name: django_stack_venv
-    image: quay.io/freedomofpress/ci-webserver:latest
-    command: /lib/systemd/systemd
-    capabilities:
-      - SYS_ADMIN
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
-      - "{{ tmp_dir }}:/venv-export"
+    image: "{{ django_stack_venv_docker_image }}"
+    command: "{{ django_stack_venv_docker_cmd|default(omit) }}"
+    capabilities: "{{ django_stack_venv_docker_cap|default(omit) }}"
+    volumes: "{{ django_stack_venv_docker_volumes + [tmp_dir+':/venv-export'] }}"
     env: "{{ django_stack_venv_env | default(omit) }}"
   delegate_to: localhost
   become: no
@@ -44,6 +41,10 @@
         extra_args: "-U"
       no_log: "{{ django_stack_venv_no_log }}"
       with_items: "{{ ['pip'] + django_stack_venv_base_pkgs }}"
+
+    - name: Optional commands to run prior to req install
+      command: "{{ item }}"
+      with_items: "{{ django_stack_venv_cmds }}"
 
     - name: Setup virtualenv from requirements file
       pip:


### PR DESCRIPTION
Turns out shipping out virtualenvs like this is not a great idea and it bit us
hard with some hard-linked system dependencies. As a quick hack, lets allow an
over-ride of the virtualenv docker builder so it can match whatever upstream
prod happens to be.

Still actively grinding on this to shake out issues -- don't merge yet :)