### PR TITLE
NPM verbosity and grsec fix

### DIFF
--- a/docker/NodeDockerfile
+++ b/docker/NodeDockerfile
@@ -1,3 +1,13 @@
 FROM node:6.11.0-alpine
 
 RUN apk add paxctl --no-cache; paxctl -cm /usr/local/bin/node
+
+USER node
+
+# See:
+#   - https://docs.npmjs.com/misc/config
+#   - https://docs.npmjs.com/cli/npm
+# for more config settings/implementation
+
+ENV npm_config_progress=false
+ENV npm_config_loglevel=warn

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -11,10 +11,15 @@
 # take a while, we'll wait for a file to be touched after the
 # npm install command exits.
 - block:
+    - name: Check for existence of grsec kernel
+      stat:
+        path: /proc/sys/kernel/grsecurity/
+      register: check_grsec_kernel_results
+
     - name: If grsec, add paxflags cmd to node
       set_fact:
         node_grsec_image: "node_grsec"
-      when: ansible_kernel.endswith('grsec')
+      when: check_grsec_kernel_results.stat.exists
 
     - name: Prepare node image with pax flags
       docker_image:


### PR DESCRIPTION
* npm verbosity -- turns down the 🔥 on the mess that is npm output
* grsec fix -- fixes grsec detection to not rely simply on kernel name