### PR TITLE
Rollback breaking commit

### DIFF
--- a/docker/NodeDockerfile
+++ b/docker/NodeDockerfile
@@ -2,8 +2,6 @@ FROM node:6.11.0-alpine
 
 RUN apk add paxctl --no-cache; paxctl -cm /usr/local/bin/node
 
-USER node
-
 # See:
 #   - https://docs.npmjs.com/misc/config
 #   - https://docs.npmjs.com/cli/npm


### PR DESCRIPTION
Turns out we cant force user to NODE for all situations (like CI). Rolling back this line until we expand CI in this repo.