### PR TITLE
Normalizes virtualenv directory names

### DIFF
--- a/tasks/pull_sitecode.yml
+++ b/tasks/pull_sitecode.yml
@@ -72,5 +72,5 @@
 
 - name: Set comparison facts to be used throughout play - II
   set_fact:
-    django_stack_venv_dir: "{{django_stack_gcorn_home}}/{{django_stack_app_name}}-{{django_stack_active_gcorn_svc}}"
+    django_stack_venv_dir: "{{ django_stack_gcorn_home }}/django-{{ django_stack_active_gcorn_svc }}"
     active_deploy_dir: "{{ django_stack_deploy_dir }}-{{ django_stack_active_gcorn_svc }}"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -7,7 +7,7 @@
 - name: Set variable for existing deploy dir checks
   set_fact:
     existing_django_deploy_dir: "{{django_stack_deploy_dir}}-{{django_stack_active_gcorn_svc}}"
-    current_venv_dir: "{{django_stack_gcorn_home}}/{{django_stack_app_name}}-{{django_stack_active_gcorn_svc}}"
+    current_venv_dir: "{{ django_stack_gcorn_home }}/django-{{ django_stack_active_gcorn_svc }}"
 
 - name: Configure gunicorn user
   user:


### PR DESCRIPTION
Rather than interpolating the app name the virtualenv directory name,
let's simply use "django-alpha" and "django-beta", same as we do for the
docroots. Doing so vastly simplifies cross-server deployments, e.g.
setting PaX flags.

Closes #43.