### PR TITLE
Fix handling for ansible_local detection in 2.4+

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -2,7 +2,7 @@
 - name: Get current active django service
   set_fact:
     django_stack_active_gcorn_svc: "{{ansible_local.active_gunicorn_svc.django.name}}"
-  when: ansible_local is defined
+  when: ansible_local|default({}) != {}
 
 - name: Set variable for existing deploy dir checks
   set_fact:


### PR DESCRIPTION
Ansible <=2.3 had a bug related to ansible_local where the value was
undefined if there were no local facts. Looks like in ansible 2.4 this
has been changed to an empty dict if local facts are not present. This
commit tweaks the checking logic to avoid key lookup errors

Fixes #38 