### PR TITLE
Adds an optional celery worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Role Variables
 --------------
 
 ```yaml
----
 # defaults file for fpf-django-stack
 django_stack_app_name: fpf
 django_stack_deploy_dir: /var/www/django
@@ -73,6 +72,9 @@ django_stack_venv_python: python3
 django_stack_venv_sitepackage: no
 django_stack_venv_no_log: "{{ django_stack_global_no_log }}"
 django_stack_venv_base_pkgs: []
+django_stack_venv_cmds: []
+django_stack_venv_docker_volumes: []
+django_stack_venv_docker_image: "quay.io/freedomofpress/ci-webserver:latest"
 django_stack_optional_pip: []
 # - name: django
 #   python: python2
@@ -161,6 +163,23 @@ django_stack_www_snippets:
   - path: /etc/nginx/snippets/proxy.conf
     template: nginx-snippet.j2
     notify: reload nginx
+
+# Over-ride this boolean to enable celery worker system service
+django_stack_celery_worker: false
+django_stack_celery_nodes: "w1"
+django_stack_celery_user: "{{ django_stack_gcorn_user }}"
+django_stack_celery_group: "{{ django_stack_gcorn_group }}"
+django_stack_celery_svc_name: "celery-www"
+django_stack_celery_svc_conf:
+  pid_file: "/var/run/celery/%n.pid"
+  log_file: "/var/log/celery/%n%I.log"
+  log_level: INFO
+  opts: "--time-limit=300 --concurrency=8"
+  nodes: "{{ django_stack_celery_nodes }}"
+  user: "{{ django_stack_celery_user }}"
+  group: "{{ django_stack_celery_group }}"
+django_stack_celery_sysd:
+  after: network.target
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -129,3 +129,20 @@ django_stack_www_snippets:
   - path: /etc/nginx/snippets/proxy.conf
     template: nginx-snippet.j2
     notify: reload nginx
+
+# Over-ride this boolean to enable celery worker system service
+django_stack_celery_worker: false
+django_stack_celery_nodes: "w1"
+django_stack_celery_user: "{{ django_stack_gcorn_user }}"
+django_stack_celery_group: "{{ django_stack_gcorn_group }}"
+django_stack_celery_svc_name: "celery-www"
+django_stack_celery_svc_conf:
+  pid_file: "/var/run/celery/%n.pid"
+  log_file: "/var/log/celery/%n%I.log"
+  log_level: INFO
+  opts: "--time-limit=300 --concurrency=8"
+  nodes: "{{ django_stack_celery_nodes }}"
+  user: "{{ django_stack_celery_user }}"
+  group: "{{ django_stack_celery_group }}"
+django_stack_celery_sysd:
+  after: network.target

--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -4,64 +4,67 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-ansible-lint==3.4.13      # via molecule
-ansible==2.3.2.0
+ansible-lint==3.4.17      # via molecule
+ansible==2.4.2.0
 anyconfig==0.9.1          # via molecule
-arrow==0.10.0             # via jinja2-time
-asn1crypto==0.22.0        # via cryptography
+arrow==0.12.0             # via jinja2-time
+asn1crypto==0.24.0        # via cryptography
+attrs==17.3.0             # via pytest
+backports.functools_lru_cache==1.2.1  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
-bcrypt==3.1.3             # via paramiko
+bcrypt==3.1.4             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
-certifi==2017.7.27.1      # via requests
-cffi==1.10.0              # via bcrypt, cryptography, pynacl
+certifi==2017.11.5        # via requests
+cffi==1.11.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
 click-completion==0.2.1   # via molecule
 click==6.7                # via click-completion, cookiecutter, git-url-parse, molecule, pip-tools, python-gilt
 colorama==0.3.7           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
 cookiecutter==1.5.1       # via molecule
-cryptography==2.0.3       # via paramiko
+cryptography==2.1.4       # via ansible, paramiko
 docker-pycreds==0.2.1     # via docker
-docker==2.5.1
+docker==2.6.1
 enum34==1.1.6             # via cryptography, flake8
 fasteners==0.14.1         # via python-gilt
 first==2.0.1              # via pip-tools
 flake8==3.3.0             # via molecule
+funcsigs==1.0.2           # via pytest
 future==0.16.0            # via cookiecutter
-git-url-parse==1.0.1      # via python-gilt
+git-url-parse==1.0.2      # via python-gilt
 idna==2.6                 # via cryptography, requests
-ipaddress==1.0.18         # via cryptography, docker
+ipaddress==1.0.19         # via cryptography, docker
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.9.6             # via ansible, click-completion, cookiecutter, jinja2-time, molecule
 markupsafe==1.0           # via jinja2
 marshmallow==2.13.5       # via molecule
 mccabe==0.6.1             # via flake8
-molecule==2.0.0.0rc16
-monotonic==1.3            # via fasteners
-paramiko==2.2.1           # via ansible
-pathspec==0.5.3           # via yamllint
+molecule==2.5.0
+monotonic==1.4            # via fasteners
+paramiko==2.4.0           # via ansible
+pathspec==0.5.5           # via yamllint
 pbr==3.0.1                # via git-url-parse, molecule, python-gilt
 pexpect==4.2.1            # via molecule
-pip-tools==1.9.0
+pip-tools==1.11.0
+pluggy==0.6.0             # via pytest
 poyo==0.4.1               # via cookiecutter
 psutil==5.2.2             # via molecule
 ptyprocess==0.5.2         # via pexpect
-py==1.4.34                # via pytest
-pyasn1==0.3.2             # via paramiko
+py==1.5.2                 # via pytest
+pyasn1==0.4.2             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
-pycrypto==2.6.1           # via ansible
 pyflakes==1.5.0           # via flake8
-pynacl==1.1.2             # via paramiko
-pytest==3.2.1             # via testinfra
+pynacl==1.2.1             # via paramiko
+pytest==3.3.1             # via testinfra
 python-dateutil==2.6.1    # via arrow
 python-gilt==1.1.0        # via molecule
 pyyaml==3.12              # via ansible, ansible-lint, molecule, python-gilt, yamllint
 requests==2.18.4          # via docker
 sh==1.12.14               # via molecule, python-gilt
-six==1.10.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, fasteners, git-url-parse, pip-tools, pynacl, python-dateutil, testinfra, websocket-client
+six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, fasteners, git-url-parse, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
 tabulate==0.7.7           # via molecule
-testinfra==1.6.3          # via molecule
+testinfra==1.7.1          # via molecule
 tree-format==0.1.1        # via molecule
 urllib3==1.22             # via requests
 websocket-client==0.44.0  # via docker

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,7 +17,7 @@
     state: started
     enabled: True
 
-- name: Start celery worker
+- name: Restart celery worker
   systemd:
     daemon_reload: yes
     name: "{{ django_stack_celery_svc_name }}.service"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,6 +17,13 @@
     state: started
     enabled: True
 
+- name: Start celery worker
+  systemd:
+    daemon_reload: yes
+    name: "{{ django_stack_celery_svc_name }}.service"
+    state: restarted
+    enabled: True
+
 - name: update gunicorn service facts
   ini_file:
     dest: /etc/ansible/facts.d/active_gunicorn_svc.fact

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -13,6 +13,8 @@
       CELERY_BIN="{{ django_stack_venv_dir }}/bin/celery"
       CELERY_APP="{{ django_stack_app_name }}"
     dest: /etc/default/celeryd
+  register: celery_config_file_result
+  notify: Restart celery worker
 
 - name: Determine if unit file already exists
   stat:
@@ -34,8 +36,8 @@
   service:
     name: "{{ django_stack_celery_svc_name }}"
     state: stopped
-  when:
-    - celery_sysd_unit_result|changed
-    - celery_sysd_path_result.stat.exists
+  when: (celery_sysd_unit_result|changed and
+         celery_sysd_path_result.stat.exists) or
+        celery_config_file_result|changed
   tags:
     - skip_ansible_lint

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -1,0 +1,24 @@
+---
+- name: Drop celery config file
+  copy:
+    content: |
+      {% for key in django_stack_celery_svc_conf.keys() %}
+      CELERYD_{{key|upper}}="{{django_stack_celery_svc_conf[key]}}"
+      {% endfor %}
+      CELERYD_CHDIR="{{ active_deploy_dir }}"
+      CELERY_BIN="{{ django_stack_venv_dir }}/bin/celery"
+      CELERY_APP="{{ django_stack_app_name }}"
+    dest: /etc/default/celeryd
+
+- name: Stop existing celery runner
+  service:
+    name: "{{ django_stack_celery_svc_name }}"
+    state: stopped
+  # The celery runner might not exist yet, lets not fail in that scenario
+  ignore_errors: true
+
+- name: Lay out systemd template
+  template:
+    src: celery.j2
+    dest: "/etc/systemd/system/{{ django_stack_celery_svc_name }}.service"
+  notify: Start celery worker

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -1,4 +1,8 @@
 ---
+- name: Establish celery task facts
+  set_fact:
+    celery_sysd_path: "/etc/systemd/system/{{ django_stack_celery_svc_name }}.service"
+
 - name: Drop celery config file
   copy:
     content: |
@@ -10,15 +14,26 @@
       CELERY_APP="{{ django_stack_app_name }}"
     dest: /etc/default/celeryd
 
-- name: Stop existing celery runner
-  service:
-    name: "{{ django_stack_celery_svc_name }}"
-    state: stopped
-  # The celery runner might not exist yet, lets not fail in that scenario
-  ignore_errors: true
+- name: Determine if unit file already exists
+  stat:
+    path: "{{ celery_sysd_path }}"
+  register: celery_sysd_path_result
 
 - name: Lay out systemd template
   template:
     src: celery.j2
-    dest: "/etc/systemd/system/{{ django_stack_celery_svc_name }}.service"
+    dest: "{{ celery_sysd_path }}"
+  register: celery_sysd_unit_result
   notify: Start celery worker
+
+# We should stop the service before the reload and restart handler b/c
+# after the template change the exec lines are completely different and point
+# to different virtualenvs. As long as we stop before systemd daemon is
+# reloaded, stopping now reflects the old unit file configuration.
+- name: Immediately stop existing celery runner on changes
+  service:
+    name: "{{ django_stack_celery_svc_name }}"
+    state: stopped
+  when:
+    - celery_sysd_unit_result|changed
+    - celery_sysd_path_result.stat.exists

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -37,3 +37,5 @@
   when:
     - celery_sysd_unit_result|changed
     - celery_sysd_path_result.stat.exists
+  tags:
+    - skip_ansible_lint

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -24,7 +24,7 @@
     src: celery.j2
     dest: "{{ celery_sysd_path }}"
   register: celery_sysd_unit_result
-  notify: Start celery worker
+  notify: Restart celery worker
 
 # We should stop the service before the reload and restart handler b/c
 # after the template change the exec lines are completely different and point

--- a/tasks/gunicorn.yml
+++ b/tasks/gunicorn.yml
@@ -1,20 +1,4 @@
 ---
-- name: Ensure run directory exists for gunicorn
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ django_stack_gcorn_user }}"
-    group: "{{ django_stack_gcorn_group }}"
-  with_items:
-    - "/run/gunicorn-{{ django_stack_active_gcorn_svc }}"
-    - "/var/log/{{ django_stack_app_name }}"
-
-- name: Define temporary run file
-  lineinfile:
-    dest: /etc/tmpfiles.d/gunicorn-{{ django_stack_active_gcorn_svc }}.conf
-    line: "d /run/gunicorn-{{django_stack_active_gcorn_svc}} 0755 {{ django_stack_gcorn_user }} {{ django_stack_gcorn_group }} -"
-    create: yes
-
 - name: Drop service and socket file
   template:
     src: "{{ item.src }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
   when:
     - current_git_hash != orig_git_hash
 
+- include: celery.yml
+  when: django_stack_celery_worker
+
 - include: django_service.yml
   tags: django
 

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -26,14 +26,6 @@
     - "{{ django_stack_static_root }}"
     - "{{ django_stack_media_root }}"
     - "{{ django_stack_logdir }}"
-
-- name: Establish django service static directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ django_stack_gcorn_user }}"
-    group: "{{ django_stack_gcorn_group }}"
-  with_items:
     - "/var/log/{{ django_stack_app_name }}"
     - "/var/log/celery"
     - "/var/run/celery"
@@ -105,11 +97,11 @@
     - ['gunicorn']
     - "{{ django_stack_gcorn_ports.keys() }}"
 
-- name: Define static run tmpfile(s)
+- name: Define celery run tmpfile(s)
   lineinfile:
-    dest: /etc/tmpfiles.d/{{ item[0] }}
-    line: "d {{item[1]}}/{{item[0]}} 0755 {{django_stack_gcorn_user}} {{django_stack_gcorn_group}} -"
+    dest: /etc/tmpfiles.d/celery
+    line: "d {{item}}/celery 0755 {{django_stack_gcorn_user}} {{django_stack_gcorn_group}} -"
     create: yes
-  with_nested:
-    - ['celery']
-    - ['/run/', '/var/log']
+  with_items:
+    - /run/
+    - /var/log

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -27,13 +27,26 @@
     - "{{ django_stack_media_root }}"
     - "{{ django_stack_logdir }}"
 
-- name: Establish code directories
+- name: Establish django service static directories
   file:
-    path: "{{ django_stack_deploy_dir }}-{{ item }}"
+    path: "{{ item }}"
     state: directory
     owner: "{{ django_stack_gcorn_user }}"
     group: "{{ django_stack_gcorn_group }}"
-  with_items: "{{ django_stack_gcorn_ports.keys() }}"
+  with_items:
+    - "/var/log/{{ django_stack_app_name }}"
+    - "/var/log/celery"
+    - "/var/run/celery"
+
+- name: Establish django service dynamic directories
+  file:
+    path: "{{ item[0] }}-{{ item[1] }}"
+    state: directory
+    owner: "{{ django_stack_gcorn_user }}"
+    group: "{{ django_stack_gcorn_group }}"
+  with_nested:
+    - ["{{django_stack_deploy_dir}}", "/run/gunicorn"]
+    - "{{ django_stack_gcorn_ports.keys() }}"
   register: check_first_time_results
 
 - name: Touch log file
@@ -82,3 +95,21 @@
   stat:
     path: "{{ current_venv_dir }}"
   register: venv_check_results
+
+- name: Define dynamic run tmpfile(s)
+  lineinfile:
+    dest: /etc/tmpfiles.d/{{ item[0] }}-{{ item[1] }}.conf
+    line: "d /run/{{item[0]}}-{{item[1]}} 0755 {{django_stack_gcorn_user}} {{django_stack_gcorn_group}} -"
+    create: yes
+  with_nested:
+    - ['gunicorn']
+    - "{{ django_stack_gcorn_ports.keys() }}"
+
+- name: Define static run tmpfile(s)
+  lineinfile:
+    dest: /etc/tmpfiles.d/{{ item[0] }}
+    line: "d {{item[1]}}/{{item[0]}} 0755 {{django_stack_gcorn_user}} {{django_stack_gcorn_group}} -"
+    create: yes
+  with_nested:
+    - ['celery']
+    - ['/run/', '/var/log']

--- a/templates/celery.j2
+++ b/templates/celery.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Celery Service
+After={{ django_stack_celery_sysd.after }}
+
+[Service]
+Type=forking
+User={{ django_stack_gcorn_user }}
+Group={{ django_stack_gcorn_group }}
+EnvironmentFile=-/home/gcorn/.gunicorn-env
+EnvironmentFile=/etc/default/celeryd
+WorkingDirectory={{ active_deploy_dir }}
+ExecStart=/bin/sh -c '${CELERY_BIN} multi start ${CELERYD_NODES} \
+  -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait ${CELERYD_NODES} \
+  --pidfile=${CELERYD_PID_FILE}'
+ExecReload=/bin/sh -c '${CELERY_BIN} multi restart ${CELERYD_NODES} \
+  -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+  --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds an optional celery worker into the mix. It won't install the actual messaging queue (like a rabbitmq) - that's up to another role/playbook to handle.

It is also up to the author of the playbook that takes advantage of this feature to add `celery` to their requirements file and add appropriate celery settings to the environment and to their django code-base.