### PR TITLE
Celery directories, tmpfile defs only when true

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -27,8 +27,8 @@
     - "{{ django_stack_media_root }}"
     - "{{ django_stack_logdir }}"
     - "/var/log/{{ django_stack_app_name }}"
-    - "/var/log/celery"
-    - "/var/run/celery"
+    - "{{ '/var/log/celery' if django_stack_celery_worker else [] }}"
+    - "{{ '/var/run/celery' if django_stack_celery_worker else [] }}"
 
 - name: Establish django service dynamic directories
   file:
@@ -105,3 +105,4 @@
   with_items:
     - /run/
     - /var/log
+  when: django_stack_celery_worker


### PR DESCRIPTION
Caught this trying to target a completely separate role and realized the
`always` tag here was getting run and these celery tasks were also
getting tacked on. Let's enforce that they are only created when
django_stack_celery_worker is set to `true.