### PR TITLE
Allow over-riding requirements path per project

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,9 @@ django_stack_gcorn_workers: 8
 django_stack_gcorn_threads: 4
 django_stack_gcorn_loglevel: info
 
+# Relative path to requirements file from root of repository
+django_stack_requirements_path: requirements.txt
+
 # If you want to try to keep output to a minimum, toggle this on.
 # For example, in CI verbose built output can obscure relevant test info.
 django_stack_global_no_log: no

--- a/devops/requirements.in
+++ b/devops/requirements.in
@@ -1,4 +1,4 @@
-ansible>=2.3
+ansible<2.6
 docker
-molecule>=2.*
+molecule
 pip-tools

--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -4,69 +4,72 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-ansible-lint==3.4.17      # via molecule
-ansible==2.4.2.0
-anyconfig==0.9.1          # via molecule
-arrow==0.12.0             # via jinja2-time
+ansible-lint==3.4.23      # via molecule
+ansible==2.5.14
+anyconfig==0.9.7          # via molecule
+arrow==0.13.0             # via jinja2-time
 asn1crypto==0.24.0        # via cryptography
-attrs==17.3.0             # via pytest
-backports.functools_lru_cache==1.2.1  # via arrow
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
+backports.functools-lru-cache==1.5  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
-bcrypt==3.1.4             # via paramiko
+bcrypt==3.1.5             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
-certifi==2017.11.5        # via requests
-cffi==1.11.2              # via bcrypt, cryptography, pynacl
+cerberus==1.2             # via molecule
+certifi==2018.11.29       # via requests
+cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
-click-completion==0.2.1   # via molecule
-click==6.7                # via click-completion, cookiecutter, git-url-parse, molecule, pip-tools, python-gilt
-colorama==0.3.7           # via molecule, python-gilt
+click-completion==0.3.1   # via molecule
+click==6.7                # via click-completion, cookiecutter, molecule, pip-tools, python-gilt
+colorama==0.3.9           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
-cookiecutter==1.5.1       # via molecule
-cryptography==2.1.4       # via ansible, paramiko
-docker-pycreds==0.2.1     # via docker
-docker==2.6.1
+cookiecutter==1.6.0       # via molecule
+cryptography==2.4.2       # via ansible, paramiko
+docker-pycreds==0.4.0     # via docker
+docker==3.6.0
 enum34==1.1.6             # via cryptography, flake8
 fasteners==0.14.1         # via python-gilt
-first==2.0.1              # via pip-tools
-flake8==3.3.0             # via molecule
+flake8==3.5.0             # via molecule
 funcsigs==1.0.2           # via pytest
-future==0.16.0            # via cookiecutter
-git-url-parse==1.0.2      # via python-gilt
-idna==2.6                 # via cryptography, requests
-ipaddress==1.0.19         # via cryptography, docker
+future==0.17.1            # via cookiecutter
+git-url-parse==1.1.0      # via python-gilt
+idna==2.8                 # via cryptography, requests
+ipaddress==1.0.22         # via cryptography, docker
 jinja2-time==0.2.0        # via cookiecutter
-jinja2==2.9.6             # via ansible, click-completion, cookiecutter, jinja2-time, molecule
-markupsafe==1.0           # via jinja2
-marshmallow==2.13.5       # via molecule
+jinja2==2.10              # via ansible, click-completion, cookiecutter, jinja2-time, molecule
+markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8
-molecule==2.5.0
-monotonic==1.4            # via fasteners
-paramiko==2.4.0           # via ansible
-pathspec==0.5.5           # via yamllint
-pbr==3.0.1                # via git-url-parse, molecule, python-gilt
-pexpect==4.2.1            # via molecule
-pip-tools==1.11.0
-pluggy==0.6.0             # via pytest
-poyo==0.4.1               # via cookiecutter
-psutil==5.2.2             # via molecule
-ptyprocess==0.5.2         # via pexpect
-py==1.5.2                 # via pytest
-pyasn1==0.4.2             # via paramiko
+molecule==2.19.0
+monotonic==1.5            # via fasteners
+more-itertools==5.0.0     # via pytest
+paramiko==2.4.2           # via ansible
+pathlib2==2.3.3           # via pytest
+pathspec==0.5.9           # via yamllint
+pbr==4.1.0                # via git-url-parse, molecule, python-gilt
+pexpect==4.6.0            # via molecule
+pip-tools==3.2.0
+pluggy==0.8.0             # via pytest
+poyo==0.4.2               # via cookiecutter
+psutil==5.4.6             # via molecule
+ptyprocess==0.6.0         # via pexpect
+py==1.7.0                 # via pytest
+pyasn1==0.4.5             # via paramiko
 pycodestyle==2.3.1        # via flake8
-pycparser==2.18           # via cffi
-pyflakes==1.5.0           # via flake8
-pynacl==1.2.1             # via paramiko
-pytest==3.3.1             # via testinfra
-python-dateutil==2.6.1    # via arrow
-python-gilt==1.1.0        # via molecule
-pyyaml==3.12              # via ansible, ansible-lint, molecule, python-gilt, yamllint
-requests==2.18.4          # via docker
+pycparser==2.19           # via cffi
+pyflakes==1.6.0           # via flake8
+pynacl==1.3.0             # via paramiko
+pytest==4.1.0             # via testinfra
+python-dateutil==2.7.5    # via arrow
+python-gilt==1.2.1        # via molecule
+pyyaml==3.13              # via ansible, ansible-lint, molecule, python-gilt, yamllint
+requests==2.21.0          # via cookiecutter, docker
+scandir==1.9.0            # via pathlib2
 sh==1.12.14               # via molecule, python-gilt
-six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, fasteners, git-url-parse, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
-tabulate==0.7.7           # via molecule
-testinfra==1.7.1          # via molecule
-tree-format==0.1.1        # via molecule
-urllib3==1.22             # via requests
-websocket-client==0.44.0  # via docker
-whichcraft==0.4.1         # via cookiecutter
-yamllint==1.8.1           # via molecule
+six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, fasteners, molecule, more-itertools, pathlib2, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
+tabulate==0.8.2           # via molecule
+testinfra==1.16.0         # via molecule
+tree-format==0.1.2        # via molecule
+urllib3==1.24.1           # via requests
+websocket-client==0.54.0  # via docker
+whichcraft==0.5.2         # via cookiecutter
+yamllint==1.11.1          # via molecule

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -48,7 +48,7 @@
 
     - name: Setup virtualenv from requirements file
       pip:
-        requirements: "/venv-export/git/requirements.txt"
+        requirements: "/venv-export/git/{{ django_stack_requirements_path }}"
         virtualenv: "{{ django_stack_venv_dir }}"
         virtualenv_python: "{{ django_stack_venv_python }}"
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"

--- a/tasks/check_git.yml
+++ b/tasks/check_git.yml
@@ -16,7 +16,7 @@
 
 - name: Check for pre-existing stats on requirements.txt file
   stat:
-    path: "{{ existing_django_deploy_dir }}/requirements.txt"
+    path: "{{ existing_django_deploy_dir }}/{{ django_stack_requirements_path }}"
     checksum_algorithm: sha256
     get_md5: false
   register: orig_req_file_results

--- a/tasks/pull_sitecode.yml
+++ b/tasks/pull_sitecode.yml
@@ -46,7 +46,7 @@
 
     - name: Check hash of current requirements.txt file
       stat:
-        path: "{{ tmp_dir_git }}/requirements.txt"
+        path: "{{ tmp_dir_git }}/{{ django_stack_requirements_path }}"
         checksum_algorithm: sha256
         get_md5: false
       register: current_req_file_results


### PR DESCRIPTION
The requirements.txt path can vary per django project. Lets set a sane
default and allow over-ride via ansible variable.