### PR TITLE
Properly passes Node container version during build

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,8 @@ django_stack_node_ver: 6.11.0-alpine
 # Default to a slim node Dockerfile shipped with role, but permit overrides.
 django_stack_node_dockerfile: "{{ role_path }}/docker/NodeDockerfile"
 django_stack_node_dockercontext: "{{ role_path }}/docker"
+django_stack_node_buildargs:
+  NODE_VER: "{{ django_stack_node_ver }}"
 
 django_stack_pkgs:
   - gcc

--- a/docker/NodeDockerfile
+++ b/docker/NodeDockerfile
@@ -1,4 +1,5 @@
-FROM node:6.11.0-alpine
+ARG NODE_VER
+FROM node:${NODE_VER}
 
 RUN apk add paxctl --no-cache; paxctl -cm /usr/local/bin/node
 

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -33,6 +33,7 @@
       docker_container:
         name: django_stack_node
         image: "{{ node_grsec_image|default('node') }}:{{ django_stack_node_ver }}"
+        buildargs: "{{ django_stack_node_buildargs }}"
         volumes:
           - "{{ tmp_dir_git }}:{{ active_deploy_dir }}"
           - "{{ tmp_dir }}:/status"


### PR DESCRIPTION
Using `buildargs` to pass in the customizable version var for the node
container that's already present in the role logic.

Closes #52.