### PR TITLE
Updates default node version 6.11.0 -> 10.15.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ django_stack_npm_no_log: "{{ django_stack_global_no_log }}"
 django_stack_npm_global_pkgs: []
 django_stack_shell_commands: []
 # This is the tag for the node image used locally to prepare the code
-django_stack_node_ver: 6.11.0-alpine
+django_stack_node_ver: 10.15.1-alpine
 
 # Default to a slim node Dockerfile shipped with role, but permit overrides.
 django_stack_node_dockerfile: "{{ role_path }}/docker/NodeDockerfile"


### PR DESCRIPTION
The NodeJS 6.x series approaching EOL (2019-04), but the 10.x series is
supported until 2021-04. Let's bump the default to avoid regressions
down the road. We can override at the site level for subsequent version
bumps.