### PR TITLE
Adds support for a version endpoint URL file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -151,3 +151,7 @@ django_stack_celery_svc_conf:
   group: "{{ django_stack_celery_group }}"
 django_stack_celery_sysd:
   after: network.target
+# relative path to a version file script which dumps server data to disk
+# this file will be ingested by a django endpoint if coded into the app
+django_stack_version_script: ""
+django_stack_version_file: /deploy/version

--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -32,6 +32,14 @@
   no_log: true
   notify: Restart Gunicorn
 
+- name: Ensure deploy directory created, writable by gcorn user
+  file:
+    state: directory
+    path: "{{ django_stack_version_file | dirname }}"
+    mode: 0755
+    owner: "{{ django_stack_gcorn_user }}"
+    group: "{{ django_stack_gcorn_group }}"
+
 - block:
     # Designed to only be one once per install
     - name: Django optional pre db commands
@@ -65,6 +73,15 @@
       with_items: ["{{ django_stack_manage_post }}"]
       ignore_errors: "{{ django_stack_manage_post_ignore }}"
       when: "django_first_install"
+
+    - name: Run version script
+      command: "{{ django_stack_version_script }}"
+      args:
+        chdir: "{{ active_deploy_dir }}"
+      environment:
+        DJANGO_VERSION_FILE: "{{ django_stack_version_file }}"
+        PATH: "{{ django_stack_venv_dir }}/bin:{{ ansible_env.PATH }}"
+      when: django_stack_version_script != ""
 
   become_user: "{{ django_stack_gcorn_user }}"
   become: yes


### PR DESCRIPTION
Support for this has to be coded into the application and is disabled by
default. This means you need the following:

* an endpoint in your app to read from a text file at
  `django_stack_version_file`
* a script in your app repository that can be referenced in
  `django_stack_version_script` that will accept env var
  `DJANGO_VERSION_FILE` (referencing spot on disk to dump file)