### PR TITLE
Adds requisite hashes and github-requirements where used

### DIFF
--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -53,6 +53,26 @@
         virtualenv_python: "{{ django_stack_venv_python }}"
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
       no_log: "{{ django_stack_venv_no_log }}"
+      when: django_stack_github_requirements_path is not defined
+
+    - name: Setup virtualenv from requriements file with requisite hashes
+      pip:
+        requirements: "/venv-export/git/{{ django_stack_requirements_path }}"
+        virtualenv: "{{ django_stack_venv_dir }}"
+        virtualenv_python: "{{ django_stack_venv_python }}"
+        virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
+        extra_args: --require-hashes
+      no_log: "{{ django_stack_venv_no_log }}"
+      when: django_stack_github_requirements_path is defined
+
+    - name: Setup virtualenv additional github requirements
+      pip:
+        requirements: "/venv-export/git/{{ django_stack_github_requirements_path }}"
+        virtualenv: "{{ django_stack_venv_dir }}"
+        virtualenv_python: "{{ django_stack_venv_python }}"
+        virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
+      no_log: "{{ django_stack_venv_no_log }}"
+      when: django_stack_github_requirements_path is defined
 
     - name: Move remote virtualenv into docker exportable filespace
       command: mv {{django_stack_venv_dir}} /venv-export/{{django_stack_app_name}}


### PR DESCRIPTION
This checks for a var called `django_stack_github_requirements_path`, and if defined, requires hashes for `requirements.txt` as well as also providing that new requirements file to `pip`.

This is based loosely on the pseudocode kindly provided by @harrislapiroff:

```
if requirements-github.txt exist:
    run "pip install --require-hashes -r requirements.txt"
    run "pip install -r requirements-github.txt"
else:
    run "pip install -r requirements.txt"
```

This also requires a new group_var for each site:
```
django_stack_github_requirements_path: requirements-github.txt
```
(see https://github.com/freedomofpress/infrastructure/pull/2195)