### PR TITLE
Fix pip perms

### DIFF
--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -74,6 +74,12 @@
       no_log: "{{ django_stack_venv_no_log }}"
       when: django_stack_github_requirements_path is defined
 
+    # Hack around a probable bug in pip 20.1b1 that leaves INSTALLER and
+    # RECORD files unreadable by any other user than root, which will prevent
+    # rsyncing them as an unprivileged user from outside the container
+    - name: Ensure contents of virtualenv are world-readable
+      command: find {{ django_stack_venv_dir }} -type f -perm 0600 -exec chmod +r {} \;
+
     - name: Move remote virtualenv into docker exportable filespace
       command: mv {{django_stack_venv_dir}} /venv-export/{{django_stack_app_name}}
 

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -81,7 +81,7 @@
       file:
         path: "{{ django_stack_venv_dir }}"
         recurse: yes
-        mode: o=rX
+        mode: g=rX,o=rX
 
     - name: Move remote virtualenv into docker exportable filespace
       command: mv {{django_stack_venv_dir}} /venv-export/{{django_stack_app_name}}

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -40,7 +40,7 @@
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
         extra_args: "-U"
       no_log: "{{ django_stack_venv_no_log }}"
-      with_items: "{{ ['pip==20.0.2'] + django_stack_venv_base_pkgs }}"
+      with_items: "{{ ['pip'] + django_stack_venv_base_pkgs }}"
 
     - name: Optional commands to run prior to req install
       command: "{{ item }}"

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -78,7 +78,10 @@
     # RECORD files unreadable by any other user than root, which will prevent
     # rsyncing them as an unprivileged user from outside the container
     - name: Ensure contents of virtualenv are world-readable
-      command: find {{ django_stack_venv_dir }} -type f -perm 0600 -exec chmod +r {} \;
+      file:
+        path: "{{ django_stack_venv_dir }}"
+        recurse: yes
+        mode: o=rX
 
     - name: Move remote virtualenv into docker exportable filespace
       command: mv {{django_stack_venv_dir}} /venv-export/{{django_stack_app_name}}

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -40,7 +40,7 @@
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
         extra_args: "-U"
       no_log: "{{ django_stack_venv_no_log }}"
-      with_items: "{{ ['pip'] + django_stack_venv_base_pkgs }}"
+      with_items: "{{ ['pip==20.0.2'] + django_stack_venv_base_pkgs }}"
 
     - name: Optional commands to run prior to req install
       command: "{{ item }}"


### PR DESCRIPTION
Work towards https://github.com/freedomofpress/infrastructure/issues/2557 (still need a PR in `infrastructure` to update this submodule)

I chose not to include the version pin here because it doesn't actually help; applying the permissions is still necessary. Went for `rX` for both group and other; compared to the `find` solution, it's setting this on a lot of files that don't need it, but it doesn't shell out which is always a plus.