### PR TITLE
Cron

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,6 +135,11 @@ django_stack_www_snippets:
     template: nginx-snippet.j2
     notify: reload nginx
 
+# Add something to the command list if you want to run manage.py crons
+django_stack_managepy_cron_job: /usr/local/bin/django-managepy-cron
+django_stack_managepy_cron_log: /var/log/django-managepy-cron.log
+django_stack_managepy_commands: []
+
 # Over-ride this boolean to enable celery worker system service
 django_stack_celery_worker: false
 django_stack_celery_nodes: "w1"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -37,8 +37,11 @@
   cron:
     name: run daily manage.py commands
     user: "{{ django_stack_gcorn_user }}"
-    hour: "9"
-    minute: "0"
+    minute: "{{ django_stack_managepy_minute | default('0') }}"
+    hour: "{{ django_stack_managepy_hour | default('9') }}"
+    day: "{{ django_stack_managepy_day | default(omit) }}"
+    month: "{{ django_stack_managepy_month | default(omit) }}"
+    weekday: "{{ django_stack_managepy_weekday | default(omit) }}"
     job: "{{ django_stack_managepy_cron_job }}"
     state: present
   when: django_stack_managepy_commands != []

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,0 +1,47 @@
+---
+# Updating facts manually to ensure that we have the latest "active"
+# gcorn service, required for the tasks below.
+- setup:
+  tags:
+    - cron
+    - django
+
+- name: Ensure log file in-place, but do not touch if exists
+  copy:
+    content: ""
+    dest: "{{ django_stack_managepy_cron_log }}"
+    mode: 0644
+    owner: "{{ django_stack_gcorn_user }}"
+    group: "{{ django_stack_gcorn_user }}"
+    force: no
+  tags:
+    - cron
+    - django
+
+# Writing a wrapper script to call manage.py due to the (alpha|beta)
+# service management in the django-stack logic. Every time this role
+# is run, the script logic will be updated.
+- name: Configure script to run cron from proper docroot.
+  template:
+    src: "cron-script.j2"
+    dest: "{{ django_stack_managepy_cron_job }}"
+    mode: "0755"
+    owner: root
+    group: "{{ django_stack_gcorn_user }}"
+  when: django_stack_managepy_commands != []
+  tags:
+    - cron
+    - django
+
+- name: Configure cron job for manage.py tasks.
+  cron:
+    name: run daily manage.py commands
+    user: "{{ django_stack_gcorn_user }}"
+    hour: "9"
+    minute: "0"
+    job: "{{ django_stack_managepy_cron_job }}"
+    state: present
+  when: django_stack_managepy_commands != []
+  tags:
+    - cron
+    - django

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,5 +28,8 @@
 - include: gunicorn.yml
   tags: gunicorn
 
+- include: cron.yml
+  tags: cron
+
 - include: cleanup_local_containers.yml
   tags: docker

--- a/templates/cron-script.j2
+++ b/templates/cron-script.j2
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$(/usr/bin/whoami)" != '{{ django_stack_gcorn_user }}' ]] ; then
+    echo 'This script must be run as {{ django_stack_gcorn_user }}.'
+    exit 1
+fi
+
+django_bin="$HOME/{{ django_stack_app_name }}-{{ django_stack_active_gcorn_svc }}/bin"
+django_www="/var/www/django-{{ django_stack_active_gcorn_svc }}"
+
+# Source the correct env.
+source "$django_bin/activate"
+
+run_manage_py() {
+    if "$django_www/manage.py" "$@"; then
+        status='successful'
+    else
+        status='failed'
+    fi
+    echo "$(date --iso-8601=seconds) - $status cron: manage.py $*" >> '{{ django_stack_managepy_cron_log }}'
+}
+
+# Run each manage.py command and log results
+{% for managepy_args in django_stack_managepy_commands %}
+run_manage_py {{ managepy_args }}
+{% endfor %}


### PR DESCRIPTION
Part of https://github.com/freedomofpress/infrastructure/pull/2687.

This includes the `manage.py` wrapper extracted from SDO (there was also a version in STN which only worked for a single command) as part of the role, and some vars to define the command list and schedule.