### PR TITLE
Pins a stable version of pip

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -160,3 +160,6 @@ django_stack_celery_sysd:
 # this file will be ingested by a django endpoint if coded into the app
 django_stack_version_script: ""
 django_stack_version_file: /deploy/version
+
+# Force a specific version of pip inside the virtualenv env
+django_stack_pip_spec: "pip==20.2.4"

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -34,13 +34,12 @@
 
     - name: Create virtualenv and ensure base packages installed
       pip:
-        name: "{{ item }}"
+        name: "{{ [django_stack_pip_spec ] + django_stack_venv_base_pkgs }}"
         virtualenv: "{{ django_stack_venv_dir }}"
         virtualenv_python: "{{ django_stack_venv_python }}"
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"
         extra_args: "-U"
       no_log: "{{ django_stack_venv_no_log }}"
-      with_items: "{{ ['pip'] + django_stack_venv_base_pkgs }}"
 
     - name: Optional commands to run prior to req install
       command: "{{ item }}"


### PR DESCRIPTION
Using 20.2.4 (2020-10-16), see changelog at [0]. Encountered a problem
on deploy that implied a beta version of pip was being used.

Made it a var so we can update it later on without editing the role, if need be. 

[0] https://pip.pypa.io/en/stable/news/