### PR TITLE
Fix some deprecated syntax

### DIFF
--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -18,10 +18,9 @@
 - block:
     - name: Install system dependencies
       apt:
-        name: "{{ item }}"
+        name: "{{ django_stack_pkgs }}"
         update_cache: yes
         cache_valid_time: 3600
-      with_items: "{{ django_stack_pkgs }}"
       tags: ['pkgs']
 
     # Necessary because there is no way to pass --relocatable to virtualenv from

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -36,8 +36,8 @@
   service:
     name: "{{ django_stack_celery_svc_name }}"
     state: stopped
-  when: (celery_sysd_unit_result|changed and
+  when: (celery_sysd_unit_result is changed and
          celery_sysd_path_result.stat.exists) or
-        celery_config_file_result|changed
+        celery_config_file_result is changed
   tags:
     - skip_ansible_lint

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -81,7 +81,7 @@
   set_fact:
     tmp_dir: "{{ tmp_dir_results.path }}"
     tmp_dir_git: "{{ tmp_dir_results.path }}/git"
-    django_first_install: "{{ first_time_remote_fact_results|changed }}"
+    django_first_install: "{{ first_time_remote_fact_results is changed }}"
 
 - name: Check if virtualenv already exists
   stat:


### PR DESCRIPTION
As part of ongoing internal work, cleaning up a few trivial warnings here. To review, run your playbooks that depend on this role with `-vvvv`.