### PR TITLE
Don't use django_manage or pass environment in on command line

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,7 +104,7 @@ django_stack_deploy_src: ""
 # django post manage.py tasks
 django_stack_db_tasks:
   - migrate
-  - collectstatic
+  - collectstatic --noinput
 django_stack_manage_post: []
 django_stack_manage_post_ignore: yes
 django_stack_manage_pre: []

--- a/tasks/django_service.yml
+++ b/tasks/django_service.yml
@@ -43,21 +43,17 @@
 - block:
     # Designed to only be one once per install
     - name: Django optional pre db commands
-      django_manage:
-        command: "{{ item }}"
-        app_path: "{{ active_deploy_dir }}"
-        settings: "{{ django_stack_gcorn_app_settings }}"
-        virtualenv: "{{ django_stack_venv_dir }}"
+      shell: ". {{ django_stack_venv_dir }}/bin/activate && ./manage.py {{ item }}"
+      args:
+        chdir: "{{ active_deploy_dir }}"
       with_items: ["{{ django_stack_manage_pre }}"]
       ignore_errors: yes
       when: "django_first_install"
 
     - name: Database migrate and other idempotent tasks
-      django_manage:
-        command: "{{ item }}"
-        app_path: "{{ active_deploy_dir }}"
-        settings: "{{ django_stack_gcorn_app_settings }}"
-        virtualenv: "{{ django_stack_venv_dir }}"
+      shell: ". {{ django_stack_venv_dir }}/bin/activate && ./manage.py {{ item }}"
+      args:
+        chdir: "{{ active_deploy_dir }}"
       with_items: "{{ django_stack_db_tasks }}"
       no_log: "{{ django_stack_manage_no_log }}"
       register: database_register
@@ -65,11 +61,9 @@
 
     # Designed to only be one once per install
     - name: Django optional post db commands
-      django_manage:
-        command: "{{ item }}"
-        app_path: "{{ active_deploy_dir }}"
-        settings: "{{ django_stack_gcorn_app_settings }}"
-        virtualenv: "{{ django_stack_venv_dir }}"
+      shell: ". {{ django_stack_venv_dir }}/bin/activate && ./manage.py {{ item }}"
+      args:
+        chdir: "{{ active_deploy_dir }}"
       with_items: ["{{ django_stack_manage_post }}"]
       ignore_errors: "{{ django_stack_manage_post_ignore }}"
       when: "django_first_install"
@@ -85,4 +79,3 @@
 
   become_user: "{{ django_stack_gcorn_user }}"
   become: yes
-  environment: "{{ django_venv_vars }}"


### PR DESCRIPTION
Use of `environment` here leaks everything to the command line (logged by `sudo` and visible in `ps`). Source the venv's activate script instead. Unfortunately, `django_manage` can't do this, so we must resort to shell. For reasons I'm not clear on, `collectstatic` now attempts to read confirmation by default, and requires `--noinput` to disable this (it didn't before).

I believe that in our internal usage, the removed `settings` key is covered by the additional env we source in virtualenv activation, but I'm not sure if this breaks something else, so please take a look while reviewing.