### PR TITLE
Download and use get-pip.py to install the initial virtualenv pip

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,8 @@ django_stack_global_no_log: no
 # virtualenv and pip
 django_stack_venv_env_file: "{{ django_stack_gcorn_home }}/.gunicorn-env"
 django_stack_venv_python: python3
+django_stack_venv_get_pip_url: "https://bootstrap.pypa.io/3.5/get-pip.py"
+django_stack_venv_get_pip_hash: "sha256:8b37d310bfc355841bfff46fa3a0a2afeeaa1d66b75734d266a9da705aa2c2b0"
 django_stack_venv_sitepackage: no
 django_stack_venv_no_log: "{{ django_stack_global_no_log }}"
 django_stack_venv_base_pkgs: []

--- a/tasks/build-venv.yml
+++ b/tasks/build-venv.yml
@@ -31,9 +31,27 @@
         path: "{{ django_stack_gcorn_home }}"
         recurse: yes
 
-    - name: Create virtualenv and ensure base packages installed
+    # Virtualenv will install the latest pip before we get to the point
+    # where we can downgrade it, which breaks on 3.5 since pip 21 is
+    # using new syntax (it may be that OS-packaged virtualenv is too old
+    # to have vendored pip and setuptools). So, run the venv creation
+    # and pip install commands manually. We cannot even use OS-packaged
+    # pip for this, as it's too old; we need to manually download the
+    # last 3.5 get-pip.py.
+    - name: Download old version of get-pip.py
+      get_url:
+        url: "{{ django_stack_venv_get_pip_url }}"
+        dest: "{{ django_stack_gcorn_home }}/get-pip.py"
+        checksum: "{{ django_stack_venv_get_pip_hash }}"
+    - name: Create virtualenv and install pip
+      shell: |
+        virtualenv -p {{ django_stack_venv_python }} --no-pip {{django_stack_venv_dir }}
+        . {{ django_stack_venv_dir }}/bin/activate
+        {{ django_stack_venv_python }} {{ django_stack_gcorn_home }}/get-pip.py {{ django_stack_pip_spec }}
+
+    - name: Ensure base packages are installed in virtualenv
       pip:
-        name: "{{ [django_stack_pip_spec ] + django_stack_venv_base_pkgs }}"
+        name: "{{ django_stack_venv_base_pkgs }}"
         virtualenv: "{{ django_stack_venv_dir }}"
         virtualenv_python: "{{ django_stack_venv_python }}"
         virtualenv_site_packages: "{{ django_stack_venv_sitepackage }}"


### PR DESCRIPTION
Deploys to a droplet for the FPF site (codebase still on python 3.5) have been failing due to `virtualenv` always installing the latest pip and setuptools. After dealing with setuptools last week, a new release of pip started using f-strings (3.6+), and so we could not even `pip install pip==20` to downgrade it. If we create the venv manually, we can specify `--no-pip` and download `get-pip.py`. (Trying to bootstrap with Ubuntu 16.04 pip doesn't work, because pip 8 tries to remove itself to install pip 20, and assumes that you will be able to access things installed in /usr, but the Ansible venv module needs `pip` to actually be in the venv's `bin`).

I am not *happy* with this solution, but it allows us to hobble along with this setup for the next couple weeks.